### PR TITLE
Fix mobile menu closing

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -34,7 +34,8 @@ mobileMenu.addEventListener('click', function() {
 document.querySelectorAll('.nav-links a').forEach(link => {
     link.addEventListener('click', () => {
         if (window.innerWidth <= 768) {
-            navLinks.style.display = 'none';
+            navLinks.classList.remove('active');
+            mobileMenu.classList.remove('active');
         }
     });
 });


### PR DESCRIPTION
## Summary
- fix navLinks closing on mobile by removing active classes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f07c0b608833285fc650d49646607