### PR TITLE
Fix mobile menu toggle after navigation

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -34,7 +34,8 @@ mobileMenu.addEventListener('click', function() {
 document.querySelectorAll('.nav-links a').forEach(link => {
     link.addEventListener('click', () => {
         if (window.innerWidth <= 768) {
-            navLinks.style.display = 'none';
+            navLinks.classList.remove('active');
+            mobileMenu.classList.remove('active');
         }
     });
 });


### PR DESCRIPTION
## Summary
- ensure mobile menu closes and can reopen after choosing a navigation link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68600cfafa0c8332926044e297f6d1c8