### PR TITLE
Fix navigation logo size in instructions

### DIFF
--- a/LOGO-INSTRUCTIONS.txt
+++ b/LOGO-INSTRUCTIONS.txt
@@ -9,7 +9,7 @@ To make your new logo visible on the website:
 2. The logo should be a PNG file with transparent background for best results.
 
 3. Current settings:
-   - Navigation logo: 85px height
+   - Navigation logo: 55px height
    - Footer logo: 50px height  
    - Both have filters applied to match your green color scheme
 


### PR DESCRIPTION
## Summary
- fix navigation logo size in LOGO-INSTRUCTIONS.txt so it matches styles.css

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f09797a4c833297454eb01664440f