### PR TITLE
Fix hero image visibility

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -151,6 +151,7 @@ body {
 }
 
 .hero.with-image .hero-bg-image {
+    display: block;
     opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- ensure hero background image is displayed by overriding `display: none`

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686156b95db083329dcb89532e896579