### PR TITLE
Organise 2025 events archive and update upcoming state

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,64 +112,82 @@
             <div id="upcoming-events">
                 <h3 class="events-subtitle">Upcoming Events</h3>
                 <div class="events-grid upcoming">
-                <!-- Notice -->
-                <div class="event-card notice" data-recurring="false">
-                    <div class="event-date">
-                        <span class="month">September</span>
-                        <span class="day">23</span>
-                        <span class="year">2024</span>
+                    <div class="event-card notice" data-recurring="false">
+                        <div class="event-content">
+                            <h3>No Upcoming Events Scheduled</h3>
+                            <p class="location"><i class="fas fa-calendar-times"></i> Check back soon</p>
+                            <p>The 2025 programme has wrapped up for now. If you'd like to explore a private therapeutic session or be first to hear about new offerings, please get in touch.</p>
+                            <a href="#contact" class="event-link">Get in Contact</a>
+                        </div>
                     </div>
-                    <div class="event-content">
-                        <h3>Regular Classes Concluded</h3>
-                        <p class="location"><i class="fas fa-map-marker-alt"></i> Luna Wave, Brighton</p>
-                        <p>Thank you to everyone who joined the weekly Hatha class. Our last session took place on 23 September, and there are no further group classes scheduled this year.</p>
-                    </div>
-                </div>
+                </div> <!-- .events-grid.upcoming -->
+            </div> <!-- #upcoming-events -->
 
-                <!-- 1-2-1 Invitation -->
-                <div class="event-card special" data-recurring="false">
-                    <div class="event-date">
-                        <span class="day">Get in Touch</span>
+            <div id="past-events">
+                <h3 class="events-subtitle">Past Events</h3>
+                <div class="events-grid past">
+                    <div class="event-card" data-recurring="false">
+                        <div class="event-date">
+                            <span class="month">April</span>
+                            <span class="day">15</span>
+                            <span class="year">2025</span>
+                        </div>
+                        <div class="event-content">
+                            <h3>Tuesday Therapeutic Hatha Series</h3>
+                            <p class="location"><i class="fas fa-map-marker-alt"></i> Luna Wave Studio, Brighton</p>
+                            <p>The weekly 5:15&nbsp;pm class series concluded in April 2025, closing a nourishing run of community practice anchored in breath-led movement and mindful alignment.</p>
+                            <p class="event-note">Thank you to everyone who joined and helped create a grounded mid-week ritual.</p>
+                        </div>
                     </div>
-                    <div class="event-content">
-                        <h3>1-2-1 Therapeutic Yoga</h3>
-                        <p class="location"><i class="fas fa-envelope"></i> Available by appointment</p>
-                        <p>Although the group timetable has wrapped up, I'm here for personalised therapeutic sessions to support your wellbeing goals. Reach out to arrange a one-to-one practice tailored to you.</p>
-                        <a href="#contact" class="event-link">Contact Me</a>
-                    </div>
-                </div>
-            </div> <!-- .events-grid.upcoming -->
-        </div> <!-- #upcoming-events -->
 
-        <div id="past-events">
-            <h3 class="events-subtitle">Past Events</h3>
-            <div class="events-grid past">
-                <div class="event-card workshop past-highlight">
-                    <div class="event-date">
-                        <span class="month">September</span>
-                        <span class="day">16</span>
-                        <span class="year">2024</span>
+                    <div class="event-card" data-recurring="false">
+                        <div class="event-date">
+                            <span class="month">June</span>
+                            <span class="day">21</span>
+                            <span class="year">2025</span>
+                        </div>
+                        <div class="event-content">
+                            <h3>International Yoga Day Gathering</h3>
+                            <p class="location"><i class="fas fa-map-marker-alt"></i> Brighton Seafront</p>
+                            <p>A sunrise practice celebrating community and connection beside the sea, weaving pranayama, slow flow, and reflective journaling to honour the spirit of International Yoga Day.</p>
+                        </div>
                     </div>
-                    <div class="event-content">
-                        <h3>Open Heart, Grounded Mind</h3>
-                        <p class="location"><i class="fas fa-map-marker-alt"></i> Yoga Workshop, Southampton</p>
-                        <p>A transformative workshop focusing on heart-opening practices and grounding techniques for mental clarity and emotional balance.</p>
-                        <p class="event-note">Want a feel for the day? Read the Southampton Yoga Association’s reflections from the 13 September 2024 session.</p>
-                        <a href="https://bookwhen.com/sya/e/ev-slxq-20250913100000" target="_blank" class="event-link">Book Workshop</a>
-                        <a href="https://www.southamptonyoga.org.uk/post/heart-opening-and-grounding-with-ankit" target="_blank" class="event-link secondary">Read the 2024 workshop review</a>
-                    </div>
-                </div>
-            </div> <!-- .events-grid.upcoming -->
-        </div> <!-- #upcoming-events -->
 
-        <div id="past-events">
-            <h3 class="events-subtitle">Past Events</h3>
-            <div class="events-grid past"></div>
-            <div class="past-events-note">
-                <p>The 13 September 2024 Open Heart, Grounded Mind workshop with the Southampton Yoga Association explored supported backbends, steady breathwork, and grounding meditation to open through the heart space.</p>
-                <a href="https://www.southamptonyoga.org.uk/post/heart-opening-and-grounding-with-ankit" target="_blank" class="event-link">Read the Southampton Yoga Association review</a>
+                    <div class="event-card" data-recurring="false">
+                        <div class="event-date">
+                            <span class="month">July</span>
+                            <span class="day">13</span>
+                            <span class="year">2025</span>
+                        </div>
+                        <div class="event-content">
+                            <h3>Buddhafield Festival 2025</h3>
+                            <p class="location"><i class="fas fa-map-marker-alt"></i> Green Earth Awakening, Somerset</p>
+                            <p>Guided a heart-centred therapeutic yoga session in the healing field, inviting festival-goers to ground, breathe deeply, and reconnect with stillness amid the celebration.</p>
+                        </div>
+                    </div>
+
+                    <div class="event-card workshop past-highlight" data-recurring="false">
+                        <div class="event-date">
+                            <span class="month">September</span>
+                            <span class="day">13</span>
+                            <span class="year">2025</span>
+                        </div>
+                        <div class="event-content">
+                            <h3>Open Heart, Grounded Mind</h3>
+                            <p class="location"><i class="fas fa-map-marker-alt"></i> Yoga Workshop, Southampton</p>
+                            <p>This deeply restorative day combined supported backbends, pranayama, and grounding meditation to cultivate balance between expansion and steadiness.</p>
+                            <p class="event-note">Want a feel for the day? Read the Southampton Yoga Association’s reflections from the 2024 gathering.</p>
+                            <a href="https://bookwhen.com/sya/e/ev-slxq-20250913100000" target="_blank" class="event-link">Event Archive</a>
+                            <a href="https://www.southamptonyoga.org.uk/post/heart-opening-and-grounding-with-ankit" target="_blank" class="event-link secondary">Read the workshop review</a>
+                        </div>
+                    </div>
+                </div> <!-- .events-grid.past -->
+
+                <div class="past-events-note">
+                    <p>The 13 September 2025 Open Heart, Grounded Mind workshop with the Southampton Yoga Association drew on Iyengar-inspired alignment, supported backbends, and steady breathwork to open through the heart space.</p>
+                    <a href="https://www.southamptonyoga.org.uk/post/heart-opening-and-grounding-with-ankit" target="_blank" class="event-link">Read the Southampton Yoga Association review</a>
+                </div>
             </div>
-        </div>
 
             <div class="events-cta">
                 <p>Looking forward to seeing familiar faces and meeting new ones.<br>Feel free to DM with any questions or just come say hi after class!</p>


### PR DESCRIPTION
## Summary
- move the 2025 offerings from the upcoming list into a dated past events timeline
- show a contact call-to-action when no new events are scheduled
- refresh copy so the Southampton workshop clearly references 2025 and links to the archive

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e56dcc3cd88332a71728c29e626636